### PR TITLE
Match rewrite targets against pathname and not entire url

### DIFF
--- a/rewrite.js
+++ b/rewrite.js
@@ -1,11 +1,14 @@
+var url = require('url');
 
 function rewriter(req, res, next) {
-    var result = req.app.match(req.url);
+    var requrl = url.parse(req.url);
+    var result = req.app.match(requrl.pathname);
     result.forEach(function(item) {
         item.callbacks.forEach(function(callback) {
             if (callback && callback.rewriteTarget) {
                 req.urlRewritten = req.url;
-                req.url = req.url.replace(item.regexp, callback.rewriteTarget);
+                requrl.pathname = requrl.pathname.replace(item.regexp, callback.rewriteTarget);
+                req.url = url.format(requrl);
             }
         });
     });


### PR DESCRIPTION
Issue: hitting an express app with a rewrite target for `/xxx` with a
request to `/xxx?hello=1` will respond with 500 server error.

This is beacuse the route matching in `rewrite.js` is done against the
entire url and not only the pathname.

Instead of matching against the entire url, use only `url.pathname` when
matching rewrite targets.
